### PR TITLE
Add build script for Cloudflare Pages build

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
         "crochet-stitcher",
         "crochetcraft"
     ],
+    "scripts": {
+        "build": "yarn workspace crochet-stitcher build && yarn workspace crochetcraft build"
+    },
     "devDependencies": {
         "@types/jest": "^29.5.12",
         "@types/node": "^20.14.11"


### PR DESCRIPTION
This adds a build script in the root package.json which is intended to be run by Cloudflare Pages. Instead of only building the crochetcraft web app, it also builds the crochet-stitcher library as it should. This simplifies the build process on the Cloudflare Pages side.