### PR TITLE
Copy-Paste Elaborator

### DIFF
--- a/crochet-stitcher/src/stages/3-placer/naivePlacerEstimator.ts
+++ b/crochet-stitcher/src/stages/3-placer/naivePlacerEstimator.ts
@@ -83,7 +83,7 @@ export function naivePlacer(pattern: Pattern<LinkedStitch>) {
                     ...(index < maxIndex ? [index + 1] : []),
                 ],
                 position: placementPoint,
-                orientation: { a: 0, b: 0, c: 0, d: 0 },
+                orientation: { a: 0.7071, b: 0, c: 0, d: direction * -0.7071 },
             });
             // Update position for the next point to place
             placementPoint = {

--- a/crochet-stitcher/src/stages/4-elaborator.ts
+++ b/crochet-stitcher/src/stages/4-elaborator.ts
@@ -1,5 +1,9 @@
 import { Pattern, PlacedStitch, Point } from '../types.js';
+import { copyPasteStitches } from './4-elaborator/copyPasteElaborator.js';
+import { Mesh, BufferGeometry, NormalBufferAttributes, Material, Object3DEventMap } from 'three';
 
-export function elaborate(input: Pattern<PlacedStitch>): Pattern<Point> {
-    throw 0; // TODO
+export function elaborate(
+    input: Pattern<PlacedStitch>,
+): Mesh<BufferGeometry<NormalBufferAttributes>, Material | Material[], Object3DEventMap>[] {
+    return copyPasteStitches(input);
 }

--- a/crochet-stitcher/src/stages/4-elaborator/bezier.ts
+++ b/crochet-stitcher/src/stages/4-elaborator/bezier.ts
@@ -1,0 +1,31 @@
+import { CubicBezierCurve3, Vector3 } from 'three';
+
+/**
+ * Creates an array of CubicBezierCurve3's from the set of given points.
+ * Requires an input of `1 + 3k` points to produce k Bezier curves.
+ * Points should be provided in the format:
+ *
+ * `[anchor, pivot, pivot, anchor, pivot, pivot, anchor, ...]`
+ *
+ * The `i`th Bezier curve uses points in `points[1 + 3(i-1), 1 + 3i]`,
+ * so each curve shares its starting and endpoint anchors with the
+ * previous or next curve respectively.
+ *
+ * e.g., Given 10 points, three curves will be produced:
+ * - The first curve uses points[0..3]
+ * - The second curve uses points [3..6]
+ * - The third curve uses points [6..9]
+ *
+ * For a smooth curve, make sure that for each anchor (other than the first and last),
+ * that the pivots before and after that anchor lie on lie on a line passing through that anchor.
+ */
+export function makeMultiBezier(points: Vector3[]) {
+    if (points.length % 3 != 1 || points.length < 4) {
+        console.error('Invalid input to makeMultiBezier! (See the comment for input format)');
+    }
+    const curves: CubicBezierCurve3[] = [];
+    for (let i = 0; i < points.length - 1; i += 3) {
+        curves.push(new CubicBezierCurve3(points[i], points[i + 1], points[i + 2], points[i + 3]));
+    }
+    return curves;
+}

--- a/crochet-stitcher/src/stages/4-elaborator/copyPasteElaborator.ts
+++ b/crochet-stitcher/src/stages/4-elaborator/copyPasteElaborator.ts
@@ -32,15 +32,33 @@ import {
 export function copyPasteStitches(
     placedStitches: Pattern<PlacedStitch>,
 ): Mesh<BufferGeometry<NormalBufferAttributes>, Material | Material[], Object3DEventMap>[] {
-    return placedStitches.stitches
-        .map((stitch) => {
-            return {
-                ...stitch,
-                ...substituteStitch(stitch),
-            };
-        })
-        .map(movePointsToPlacement)
-        .flatMap(curveToGeometries);
+    return (
+        placedStitches.stitches
+            // "Copy-paste" step; for each placed stitch,
+            // add the points from the base model corresponding to its type
+            .map((stitch) => {
+                return {
+                    ...stitch,
+                    ...substituteStitch(stitch),
+                };
+            })
+            // Base models (supposedly) are centered around the origin.
+            // This moves them to where the placer thinks they should be
+            .map(movePointsToPlacement)
+            // Make stitches connect to each other, and not extremely jagged
+            .map((stitch, index, arr) => {
+                if (
+                    index == 0 ||
+                    !(stitch.curveType == 'bezier' && arr[index - 1].curveType == 'bezier')
+                ) {
+                    return stitch;
+                }
+                return startToEndFixer(stitch, arr[index - 1]);
+            })
+            // Generate geometries
+            // (This could be moved to crochetcraft)
+            .flatMap(curveToGeometries)
+    );
 }
 
 type IntermediatePlacement = PlacedStitch & StitchModel;
@@ -79,6 +97,69 @@ function movePointsToPlacement(stitch: IntermediatePlacement): IntermediatePlace
             return [rx + stitch.position.x, ry + stitch.position.y, rz + stitch.position.z];
         }),
     };
+}
+
+/**
+ * Sets the starting point of `nextStitch` to the ending point of `prevStitch`,
+ * and modifies the first anchor of `nextStitch` to be aligned with the
+ * last anchor of `prevStitch`.
+ *
+ * This ensures (bezier-curve based) stitches are continuous, and first-derivative continuous.
+ *
+ * @param nextStitch the stitch whose starting point to modify ("fix")
+ * @param prevStitch the stitch whose ending point is used to modify `nextStitch`
+ */
+function startToEndFixer(
+    nextStitch: IntermediatePlacement,
+    prevStitch: IntermediatePlacement,
+): IntermediatePlacement {
+    // Move end to start
+    const endOfPrevStitch = prevStitch.points[prevStitch.points.length - 1];
+    // Deep copy to prevent reference jank
+    nextStitch.points[0] = [endOfPrevStitch[0], endOfPrevStitch[1], endOfPrevStitch[2]];
+
+    // Reorient anchor for continuity
+    // On the one hand, this does make the chain stitch look much better.
+    // On the other, this is a lot of work to fix an issue with the original base model.
+    // (...which is my fault for the record - Allen)
+    // But on the other other hand, it's unreasonable for every base model to end in the same direction.
+
+    // Find the direction of the end of the previous stitch
+    // i.e. what way it would go if you extended it along a line
+    const prevAnchor = prevStitch.points[prevStitch.points.length - 2];
+    const prevAnchorDiff = [
+        endOfPrevStitch[0] - prevAnchor[0],
+        endOfPrevStitch[1] - prevAnchor[1],
+        endOfPrevStitch[2] - prevAnchor[2],
+    ];
+    const r = Math.sqrt(
+        prevAnchorDiff[0] * prevAnchorDiff[0] +
+            prevAnchorDiff[1] * prevAnchorDiff[1] +
+            prevAnchorDiff[2] * prevAnchorDiff[2],
+    );
+    const direction = [prevAnchorDiff[0] / r, prevAnchorDiff[1] / r, prevAnchorDiff[2] / r];
+
+    // Get the distance of the first anchor from the first point of the next stitch
+    const nextAnchorDiff = [
+        nextStitch.points[1][0] - nextStitch.points[0][0],
+        nextStitch.points[1][1] - nextStitch.points[0][1],
+        nextStitch.points[1][2] - nextStitch.points[0][2],
+    ];
+    const distance = Math.sqrt(
+        nextAnchorDiff[0] * nextAnchorDiff[0] +
+            nextAnchorDiff[1] * nextAnchorDiff[1] +
+            nextAnchorDiff[2] * nextAnchorDiff[2],
+    );
+
+    // Modify the first anchor to be aligned in the same direction as the
+    // last anchor of the previous stitch.
+    nextStitch.points[1] = [
+        nextStitch.points[0][0] + direction[0] * distance,
+        nextStitch.points[0][1] + direction[1] * distance,
+        nextStitch.points[0][2] + direction[2] * distance,
+    ];
+
+    return nextStitch;
 }
 
 /**

--- a/crochet-stitcher/src/stages/4-elaborator/copyPasteElaborator.ts
+++ b/crochet-stitcher/src/stages/4-elaborator/copyPasteElaborator.ts
@@ -20,6 +20,15 @@ import {
     MeshLambertMaterial,
 } from 'three';
 
+/**
+ * Replaces placed stitches with a set of geometries corresponding to
+ * how each stitch would actually look.
+ *
+ * This only "copy-pastes" from a template, so there is no
+ * awareness of distortion, compression, etc.
+ * @param placedStitches
+ * @returns
+ */
 export function copyPasteStitches(
     placedStitches: Pattern<PlacedStitch>,
 ): Mesh<BufferGeometry<NormalBufferAttributes>, Material | Material[], Object3DEventMap>[] {
@@ -62,6 +71,7 @@ function movePointsToPlacement(stitch: IntermediatePlacement): IntermediatePlace
         points: stitch.points.map((p) => {
             const [x, y, z] = p;
             // handrolled matmul
+            // Also, multiple by 2 to scale the stitches to what the placer thinks is right
             const rx = 2 * (x * mat[0][0] + y * mat[0][1] + z * mat[0][2]);
             const ry = 2 * (x * mat[1][0] + y * mat[1][1] + z * mat[1][2]);
             const rz = 2 * (x * mat[2][0] + y * mat[2][1] + z * mat[2][2]);
@@ -93,6 +103,12 @@ function curveToGeometries(
     }
 }
 
+/**
+ * Helper function to get the stitch model for a given placed stitch.
+ *
+ * @param stitch
+ * @returns
+ */
 function substituteStitch(stitch: PlacedStitch) {
     switch (stitch.type) {
         case StitchType.Chain:

--- a/crochet-stitcher/src/stages/4-elaborator/copyPasteElaborator.ts
+++ b/crochet-stitcher/src/stages/4-elaborator/copyPasteElaborator.ts
@@ -1,0 +1,103 @@
+/**
+ * The copy-paste elaborator is an extremely simple initial step for the elaborator
+ * which simply copies the points that make up a stitch into the position and orientation
+ * provided by the placer.
+ *
+ * No additional work is done to make the resulting stitches look "nice".
+ */
+
+import StitchModel from '../../models';
+import { Pattern, PlacedStitch, StitchType } from '../../types';
+import { makeMultiBezier } from './bezier';
+import { arrayToVector3List } from './vectorHelper';
+import {
+    Mesh,
+    BufferGeometry,
+    NormalBufferAttributes,
+    Material,
+    Object3DEventMap,
+    TubeGeometry,
+    MeshLambertMaterial,
+} from 'three';
+
+export function copyPasteStitches(
+    placedStitches: Pattern<PlacedStitch>,
+): Mesh<BufferGeometry<NormalBufferAttributes>, Material | Material[], Object3DEventMap>[] {
+    return placedStitches.stitches
+        .map((stitch) => {
+            return {
+                ...stitch,
+                ...substituteStitch(stitch),
+            };
+        })
+        .map(movePointsToPlacement)
+        .flatMap(curveToGeometries);
+}
+
+type IntermediatePlacement = PlacedStitch & StitchModel;
+
+/**
+ * Moves points of an intermediate stitch to the placement position.
+ *
+ * TODO: also rotate points to the correct orientation.
+ *
+ * @param stitch
+ * @returns
+ */
+function movePointsToPlacement(stitch: IntermediatePlacement): IntermediatePlacement {
+    // I really don't want to deal with severe rotation jank so
+    // I'll keep the quaternion as part of the interface...
+    // and just copy paste the Wikipedia conversion to a matrix.
+    // If anyone is willing to make quaternions work nicely, please do.
+    // Otherwise, I might just switch to Euler angles.
+    const { a: r, b: i, c: j, d: k } = stitch.orientation;
+    const mat = [
+        [1 - 2 * (j * j + k * k), 2 * (i * j - k * r), 2 * (i * k + j * r)],
+        [2 * (i * j + k * r), 1 - 2 * (i * i + k * k), 2 * (j * k - i * r)],
+        [2 * (i * k - j * r), 2 * (j * k + i * r), 1 - 2 * (i * i + j * j)],
+    ];
+
+    return {
+        ...stitch,
+        points: stitch.points.map((p) => {
+            const [x, y, z] = p;
+            // handrolled matmul
+            const rx = 2 * (x * mat[0][0] + y * mat[0][1] + z * mat[0][2]);
+            const ry = 2 * (x * mat[1][0] + y * mat[1][1] + z * mat[1][2]);
+            const rz = 2 * (x * mat[2][0] + y * mat[2][1] + z * mat[2][2]);
+
+            return [rx + stitch.position.x, ry + stitch.position.y, rz + stitch.position.z];
+        }),
+    };
+}
+
+/**
+ * Converts a set of points representing curves into
+ * geometries that can be rendered by THREE.
+ */
+function curveToGeometries(
+    stitch: IntermediatePlacement,
+): Mesh<TubeGeometry, MeshLambertMaterial, Object3DEventMap>[] {
+    // TODO: Make efficient
+    switch (stitch.curveType) {
+        case 'bezier':
+            const curveParts = makeMultiBezier(arrayToVector3List(stitch.points));
+            return curveParts.map((curve) => {
+                const geometry = new TubeGeometry(curve, 50, 0.1, 10);
+                const material = new MeshLambertMaterial();
+                const mesh = new Mesh(geometry, material);
+                return mesh;
+            });
+        default:
+            throw 'unsupported curve type!';
+    }
+}
+
+function substituteStitch(stitch: PlacedStitch) {
+    switch (stitch.type) {
+        case StitchType.Chain:
+            return StitchModel.CHAIN;
+        default:
+            throw 'Unsupported stitch!';
+    }
+}

--- a/crochet-stitcher/src/stages/4-elaborator/copyPasteElaborator.ts
+++ b/crochet-stitcher/src/stages/4-elaborator/copyPasteElaborator.ts
@@ -118,11 +118,13 @@ function startToEndFixer(
     // Deep copy to prevent reference jank
     nextStitch.points[0] = [endOfPrevStitch[0], endOfPrevStitch[1], endOfPrevStitch[2]];
 
-    // Reorient anchor for continuity
+    // Reorient first anchor for continuity
     // On the one hand, this does make the chain stitch look much better.
     // On the other, this is a lot of work to fix an issue with the original base model.
     // (...which is my fault for the record - Allen)
     // But on the other other hand, it's unreasonable for every base model to end in the same direction.
+
+    // Project the first pivot along the line that the last stitch's final point and pivot lie on.
 
     // Find the direction of the end of the previous stitch
     // i.e. what way it would go if you extended it along a line
@@ -132,31 +134,28 @@ function startToEndFixer(
         endOfPrevStitch[1] - prevAnchor[1],
         endOfPrevStitch[2] - prevAnchor[2],
     ];
-    const r = Math.sqrt(
-        prevAnchorDiff[0] * prevAnchorDiff[0] +
-            prevAnchorDiff[1] * prevAnchorDiff[1] +
-            prevAnchorDiff[2] * prevAnchorDiff[2],
-    );
-    const direction = [prevAnchorDiff[0] / r, prevAnchorDiff[1] / r, prevAnchorDiff[2] / r];
-
-    // Get the distance of the first anchor from the first point of the next stitch
     const nextAnchorDiff = [
         nextStitch.points[1][0] - nextStitch.points[0][0],
         nextStitch.points[1][1] - nextStitch.points[0][1],
         nextStitch.points[1][2] - nextStitch.points[0][2],
     ];
-    const distance = Math.sqrt(
-        nextAnchorDiff[0] * nextAnchorDiff[0] +
-            nextAnchorDiff[1] * nextAnchorDiff[1] +
-            nextAnchorDiff[2] * nextAnchorDiff[2],
+    const distSquared = Math.sqrt(
+        prevAnchorDiff[0] * prevAnchorDiff[0] +
+            prevAnchorDiff[1] * prevAnchorDiff[1] +
+            prevAnchorDiff[2] * prevAnchorDiff[2],
     );
+    const dotProduct =
+        prevAnchorDiff[0] * nextAnchorDiff[0] +
+        prevAnchorDiff[1] * nextAnchorDiff[1] +
+        prevAnchorDiff[2] * nextAnchorDiff[2];
+    const multiplier = distSquared / dotProduct;
 
     // Modify the first anchor to be aligned in the same direction as the
     // last anchor of the previous stitch.
     nextStitch.points[1] = [
-        nextStitch.points[0][0] + direction[0] * distance,
-        nextStitch.points[0][1] + direction[1] * distance,
-        nextStitch.points[0][2] + direction[2] * distance,
+        nextStitch.points[0][0] + prevAnchorDiff[0] * multiplier,
+        nextStitch.points[0][1] + prevAnchorDiff[1] * multiplier,
+        nextStitch.points[0][2] + prevAnchorDiff[2] * multiplier,
     ];
 
     return nextStitch;

--- a/crochet-stitcher/src/stages/4-elaborator/vectorHelper.ts
+++ b/crochet-stitcher/src/stages/4-elaborator/vectorHelper.ts
@@ -1,0 +1,9 @@
+import { Vector3 } from 'three';
+
+/**
+ * Converts a 2D array of numbers into a list of Vector3.
+ * Each array element in points should be an array of the form [x, y, z]
+ */
+export function arrayToVector3List(points: [number, number, number][]) {
+    return points.map(([x, y, z]) => new Vector3(x, y, z));
+}

--- a/crochet-stitcher/tsconfig.json
+++ b/crochet-stitcher/tsconfig.json
@@ -5,7 +5,8 @@
         "skipLibCheck": true,
         "strict": true,
         "removeComments": true,
-        "resolveJsonModule": true
+        "resolveJsonModule": true,
+        "skipLibCheck": true
     },
     "include": ["src/**/*.ts"]
 }

--- a/crochetcraft/src/routes/(experiments)/demos/e2e-hell/+page.svelte
+++ b/crochetcraft/src/routes/(experiments)/demos/e2e-hell/+page.svelte
@@ -2,7 +2,7 @@
     import ThreeCanvas from '$lib/ThreeCanvas.svelte';
     import * as THREE from 'three';
     import { Vector3 } from 'three';
-    import { parse, link, place } from 'crochet-stitcher';
+    import { parse, link, place, elaborate } from 'crochet-stitcher';
     import { placeDebugSpheres } from '$lib/render/debug';
 
     // Scene objects
@@ -16,16 +16,26 @@
     };
     const sampleNames = Object.keys(sampleInputs);
     let selectedSampleName = 'default chain';
+    let doElaboration = false;
 
     $: {
         const currentSample = sampleInputs[selectedSampleName];
-        const placedPoints = place(link(parse(currentSample)));
-
         mainGroup.clear();
-        placeDebugSpheres(
-            placedPoints.stitches.map((p) => new Vector3(p.position.x, p.position.y, p.position.z)),
-            mainGroup,
-        );
+
+        if (doElaboration) {
+            const elaboratedPoints = elaborate(place(link(parse(currentSample))));
+            console.log(elaboratedPoints);
+            elaboratedPoints.forEach((mesh) => mainGroup.add(mesh));
+        } else {
+            const placedPoints = place(link(parse(currentSample)));
+
+            placeDebugSpheres(
+                placedPoints.stitches.map(
+                    (p) => new Vector3(p.position.x, p.position.y, p.position.z),
+                ),
+                mainGroup,
+            );
+        }
         scene?.add(mainGroup);
     }
 </script>
@@ -42,6 +52,11 @@
                 <option value={sampleStr}>{sampleStr}</option>
             {/each}
         </select>
+        <br /><br />
+        <label
+            ><i>Do elaboration?</i>
+            <input type="checkbox" bind:checked={doElaboration} />
+        </label>
     </div>
 </div>
 


### PR DESCRIPTION
Extremely simple elaborator, which just barely works for an e2e demo.

(For chain stitches only), pastes the points and constructs the geometries corresponding to those points, positioned and oriented based on results from the placer.

Part of a PR stack:
`elaborator-v1 -> placer-v1 -> linker`