### PR TITLE
Set stitch orientation based on parent and children

### DIFF
--- a/crochet-stitcher/src/stages/3-placer/gd-placer.ts
+++ b/crochet-stitcher/src/stages/3-placer/gd-placer.ts
@@ -108,7 +108,9 @@ export function gdPlace(
             type: stitch.type,
             position: positions[i],
             orientation: orientations[i],
-            links: {}, // TODO
+            parents: stitch.parents,
+            children: stitch.children,
+            links: {},
         })),
     };
     return setOrientations(result);

--- a/crochet-stitcher/src/types.ts
+++ b/crochet-stitcher/src/types.ts
@@ -90,6 +90,8 @@ export interface PlacedStitch {
     type: StitchType;
     position: Vector3;
     orientation: Quaternion;
+    parents: number[] | null;
+    children: number[];
     links: {
         prev?: PlacedStitch;
         next?: PlacedStitch;

--- a/crochetcraft/src/routes/experiments/e2e-testing/+page.svelte
+++ b/crochetcraft/src/routes/experiments/e2e-testing/+page.svelte
@@ -20,44 +20,6 @@
     import { mergeGeometries } from 'three/examples/jsm/utils/BufferGeometryUtils.js';
     import Panel from '$components/option-panel/Panel.svelte';
 
-    // Example hard-coded chain stitch:
-    const ChainStitchExampleParts = makeMultiBezier([
-        new Vector3(0.0, 0.0, 0.0),
-        new Vector3(0.03989, -0.1529, 0.4265),
-        new Vector3(-0.1251, 0.1748, 0.4262),
-        new Vector3(-0.286, 0.4362, -0.05045),
-        new Vector3(-0.4751, 0.7433, -0.6106),
-        new Vector3(-0.8814, 1.054, 0.3796),
-        new Vector3(-0.1089, 1.246, 0.1362),
-        new Vector3(0.6817, 1.442, -0.1128),
-        new Vector3(-0.4605, 0.585, -0.5125),
-        new Vector3(-0.01001, 0.4943, -0.007016),
-    ]);
-
-    function makeChainStitchExample(scene: Scene, pos: Vector3 = new Vector3(0, 0, 0)) {
-        ChainStitchExampleParts.map((curve) => {
-            const geometry = new TubeGeometry(curve, 50, 0.1, 10);
-            // NOTE: May need to close TubeGeometries so that the stitch looks better...
-            const material = new MeshLambertMaterial();
-            material.side = DoubleSide; // NOTE: The side value of the material has to be double-sided for effective intersection checking.
-            material.color = new Color().setHex(Math.random() * 0xffffff);
-            material.emissive = material.color;
-            material.emissiveIntensity = 0;
-            const mesh = new Mesh(geometry, material);
-            mesh.translateX(pos.x);
-            mesh.translateY(pos.y);
-            mesh.translateZ(pos.z);
-            scene.add(mesh);
-        });
-    }
-    // Actual processing for E2E happens in the Editor.svelte file
-    // Hardcode test:
-    /*  
-        for (let i = 0; i < 10; ++i) {
-            makeChainStitchExample(scene, new THREE.Vector3(0, 0.5 * i, 0));
-        }
-    */
-
     // Scene objects
     let scene: Scene;
     let mainGroup: Group = new Group();
@@ -150,9 +112,20 @@
                             stitch.position.clone(),
                             stitch.position
                                 .clone()
+                                .add(new Vector3(0, 1, 0).applyQuaternion(stitch.orientation)),
+                        ]),
+                        new LineBasicMaterial({ color: 0x00ff00 }),
+                    ),
+                );
+                mainGroup.add(
+                    new Line(
+                        new BufferGeometry().setFromPoints([
+                            stitch.position.clone(),
+                            stitch.position
+                                .clone()
                                 .add(new Vector3(1, 0, 0).applyQuaternion(stitch.orientation)),
                         ]),
-                        new LineBasicMaterial({ color: 0xffffff }),
+                        new LineBasicMaterial({ color: 0xff0000 }),
                     ),
                 );
             });


### PR DESCRIPTION
Closes #229

This also adds a green line pointing to each stitch's local Y-axis (i.e., the direction of its children, whether or not it has any children).

## Before

![Screenshot_20250317_114040](https://github.com/user-attachments/assets/1705ebc3-8378-4e1d-aea5-a37abd74e320)

## After

![Screenshot_20250317_120716](https://github.com/user-attachments/assets/53a2f96f-d3e0-4a88-8b21-964d27c95d7a)
